### PR TITLE
Add PaliGemma 2 training toolkit with developmental metrics

### DIFF
--- a/README_PALIGEMMA2.md
+++ b/README_PALIGEMMA2.md
@@ -1,0 +1,131 @@
+# PaliGemma 2 Reproduction Toolkit
+
+This directory extends the repository with scripts and modules to reproduce and extend the **PaliGemma 2** training setup where a SigLIP-So400m vision encoder is paired with a Gemma 2 text decoder. The focus is on three-stage curriculum training, high-frequency checkpointing, and developmental-interpretability metrics.
+
+## Released assets
+
+All public checkpoints and documentation are discoverable on the Hugging Face Hub via Google DeepMind releases. The helper script `scripts/verify_assets.py` checks availability of:
+
+- PaliGemma 2 weights (`3B`, `10B`, `28B`) at input resolutions `224`, `448`, and `896`.
+- The SigLIP-So400m vision tower (`google/siglip-so400m-patch14-384`).
+- Gemma 2 instruction-tuned decoders (`google/gemma-2-2b-it`, `google/gemma-2-9b-it`, `google/gemma-2-27b-it`).
+- Public documentation/model cards (tech report and per-checkpoint cards).
+
+```bash
+python scripts/verify_assets.py
+```
+
+To download weights and optionally verify checksums/model cards:
+
+```bash
+python scripts/download_assets.py --key 3b-224 --output-dir weights --dump-card
+```
+
+SHA-256 hashes can be attached to `paligemma2.modeling.PALIGEMMA2_ASSETS` once publicly released. The downloader will warn if hashes are absent.
+
+## Environment setup
+
+```bash
+pip install -r requirements.txt  # provide torch>=2.3, transformers>=4.41, huggingface_hub, pandas, pyarrow, tensorboard
+```
+
+Optional dependencies:
+
+- `devinterp` for Log-Likelihood Curvature (LLC) estimation hooks.
+- `flash-attn` / PyTorch nightly if you plan to train the larger checkpoints.
+
+## Repository layout additions
+
+```
+paligemma2/
+  config.py               # stage configs and asset metadata
+  modeling.py             # SigLIP + Gemma fusion module + asset catalog
+  data/registry.py        # task registry with stubbed loaders (replace with real datasets)
+  training/pipeline.py    # three-stage trainer with high-frequency checkpointing
+metrics/
+  training_dev_metrics.py # developmental metrics streamer
+scripts/
+  download_assets.py      # weight/model-card downloader with hash verification
+  verify_assets.py        # probe availability of public assets
+  train.py                # curriculum trainer entry point
+  eval.py                 # checkpoint evaluation across registered tasks
+  export_activations.py   # post-hoc activation exporter
+  checkpoint_indexer.py   # summarise CHECKPOINT_MANIFEST.parquet
+```
+
+Artifacts written during training:
+
+- `CHECKPOINT_MANIFEST.parquet` – index of saved checkpoints with parameter descriptors.
+- `METRICS/train_timeseries.parquet` – streaming timeseries for loss/geometry/LLC metrics.
+- Optional TensorBoard logs if `MetricConfig.tb_dir` is provided.
+
+## Three-stage training recipe
+
+The default schedule mirrors the public recipe:
+
+1. **Stage 1** – 224px, ~1B examples, joint multimodal mix.
+2. **Stage 2** – split into 50M 448px and 10M 896px steps with OCR upweighting.
+3. **Stage 3** – per-task fine-tunes at 896px reusing Stage 2 hyperparameters.
+
+Hyperparameters live in `StageSchedule.default_schedule()` and are easily overridden.
+
+Launch training (smoke-test with short stage lengths):
+
+```bash
+python scripts/train.py --model-size 3b --precision bf16 --max-steps 10 --save-every 5 --log-dir runs/3b_smoke
+```
+
+By default the data registry uses synthetic placeholders – replace `paligemma2/data/registry.py` loaders with real datasets or plug in your own modules through the registry API.
+
+## Evaluation and post-hoc tooling
+
+Evaluate a checkpoint across registered tasks:
+
+```bash
+python scripts/eval.py --checkpoint checkpoints/ckpt_step00000200.pt --model-size 3b --resolution 448
+```
+
+Export activation snapshots for interpretability probes:
+
+```bash
+python scripts/export_activations.py --checkpoint checkpoints/ckpt_step00000200.pt \
+  --layers text_model.model.layers.0 --out activations/layer0.parquet --batches 4
+```
+
+Build a condensed manifest summary:
+
+```bash
+python scripts/checkpoint_indexer.py --log-dir runs/3b_smoke --out runs/3b_smoke/manifest_summary.json
+```
+
+## Developmental metrics
+
+`metrics/training_dev_metrics.py` streams:
+
+- Core training stats (loss, LR, batch size, gradient/weight norms).
+- Grad-to-weight ratios and optimiser momentum.
+- Hutchinson trace estimates for Hessian curvature (requires registering a closure each step, handled by the trainer).
+- Optional LLC estimates via DevInterp SGLD sampling (guarded when the package is unavailable).
+- Parameter-space descriptors (layer norms, singular value proxies, sparsity, cosine drift).
+- Plugin module hook for custom metrics.
+
+Outputs are stored as Parquet and TensorBoard scalars to enable downstream developmental-interpretability analysis.
+
+## Data mixture placeholders
+
+Because the original pretraining mixture is not public, the registry wires in synthetic datasets that emulate the expected tensor shapes. Replace the loader functions with your task-specific datasets (captioning, OCR-heavy, grounded captioning, detection/segmentation) and adjust the per-stage `task_weights` in `paligemma2/config.py`.
+
+## Testing
+
+Run unit tests to validate metric streaming and manifest handling:
+
+```bash
+pytest tests
+```
+
+## Caveats
+
+- Full pretraining datasets and certain fine-tuning corpora are not publicly released; stubs are provided instead.
+- LLC estimation can be computationally expensive and may require tuning sampler hyperparameters for stability.
+- High-resolution (896px) stages require GPUs with large memory footprints; consider gradient checkpointing/FSDP.
+

--- a/metrics/training_dev_metrics.py
+++ b/metrics/training_dev_metrics.py
@@ -1,0 +1,358 @@
+"""Training-time metric aggregation for developmental interpretability."""
+from __future__ import annotations
+
+import math
+import pathlib
+import time
+from dataclasses import dataclass, field
+from typing import Any, Dict, Iterable, List, Optional, Protocol
+
+import pandas as pd
+import torch
+from torch import nn
+from torch.utils.tensorboard import SummaryWriter
+
+try:  # pragma: no cover - optional dependency
+    from devinterp.slt.sampler import sample as devinterp_sample
+    from devinterp.slt.llc import LLCEstimator
+    from devinterp.optim import SGLD
+
+    DEVINTERP_AVAILABLE = True
+except Exception:  # pragma: no cover - optional dependency missing
+    DEVINTERP_AVAILABLE = False
+
+
+class MetricModule(Protocol):
+    """Interface for plugin metric modules."""
+
+    def __call__(self, row: Dict[str, Any], step: int) -> Optional[Dict[str, Any]]:  # pragma: no cover - protocol
+        ...
+
+
+@dataclass
+class MetricConfig:
+    """Configuration parameters for :class:`TrainingDevMetrics`."""
+
+    log_dir: str
+    tb_dir: Optional[str] = None
+    parquet_rollover_rows: int = 50_000
+    # Cadences (in steps)
+    log_every: int = 10
+    ckpt_every: int = 200
+    curvature_every: int = 1_000
+    llc_every: int = 5_000
+    activation_probe_every: int = 0
+    # Geometry settings
+    hutchinson_vecs: int = 1
+    spectral_topk: int = 8
+    # LLC settings
+    llc_batch_size: int = 1_024
+    llc_nbeta: Optional[int] = None
+    llc_max_steps: int = 200
+    llc_sampler_lr: float = 5e-4
+    # Serialization
+    manifest_name: str = "CHECKPOINT_MANIFEST.parquet"
+
+
+@dataclass
+class TrainingDevMetrics:
+    """Collect and persist metrics for the PaliGemma 2 training pipeline."""
+
+    cfg: MetricConfig
+    model: nn.Module
+    optimizer: torch.optim.Optimizer
+    global_step: int = 0
+    _tb: Optional[SummaryWriter] = field(default=None, init=False)
+    _parquet_path: pathlib.Path = field(default=None, init=False)
+    _buffer: List[Dict[str, Any]] = field(default_factory=list, init=False)
+    _curvature_closure: Optional[callable] = field(default=None, init=False)
+    _llc_loader: Optional[Iterable] = field(default=None, init=False)
+    _llc_sampler_kwargs: Dict[str, Any] = field(default_factory=dict, init=False)
+    _modules: List[MetricModule] = field(default_factory=list, init=False)
+    _prev_flat_params: Optional[torch.Tensor] = field(default=None, init=False)
+
+    def __post_init__(self) -> None:
+        self.root = pathlib.Path(self.cfg.log_dir)
+        self.root.mkdir(parents=True, exist_ok=True)
+        self.metrics_path = self.root / "METRICS"
+        self.metrics_path.mkdir(exist_ok=True)
+        self._parquet_path = self.metrics_path / "train_timeseries.parquet"
+        if self.cfg.tb_dir:
+            self._tb = SummaryWriter(self.cfg.tb_dir)
+        self._init_manifest()
+
+    # ---------- configuration hooks ----------
+    def register_curvature_closure(self, closure: callable) -> None:
+        """Register a closure that recomputes the loss for curvature probes."""
+
+        self._curvature_closure = closure
+
+    def register_llc_inputs(self, loader: Iterable, **sampler_kwargs: Any) -> None:
+        """Register a dataloader and sampler kwargs for DevInterp LLC estimation."""
+
+        self._llc_loader = loader
+        self._llc_sampler_kwargs = sampler_kwargs
+
+    def register_metric_module(self, module: MetricModule) -> None:
+        """Attach a plugin metric module executed on every log row."""
+
+        self._modules.append(module)
+
+    # ---------- public API (called from the training loop) ----------
+    def on_step_end(self, loss: float, batch_size: int, lr: float, **extras: Any) -> None:
+        """Record fast-path metrics every step (controlled by ``cfg.log_every``)."""
+
+        self.global_step += 1
+        if self.global_step % self.cfg.log_every == 0:
+            grad_norm = float(self._grad_global_norm())
+            weight_norm = float(self._weight_global_norm())
+            row: Dict[str, Any] = {
+                "ts": time.time(),
+                "step": self.global_step,
+                "loss": float(loss),
+                "lr": float(lr),
+                "batch_size": int(batch_size),
+                "grad_norm": grad_norm,
+                "weight_norm": weight_norm,
+                "grad_to_weight_ratio": self._safe_ratio(grad_norm, weight_norm),
+                "optimizer/momentum": self._get_momentum_stat(),
+            }
+            for k, v in extras.items():
+                row[f"extra/{k}"] = self._to_float(v)
+            self._log_row(row)
+
+        if self.cfg.curvature_every and self.global_step % self.cfg.curvature_every == 0:
+            self._log_curvature_proxies()
+
+        if DEVINTERP_AVAILABLE and self.cfg.llc_every and self.global_step % self.cfg.llc_every == 0:
+            self._log_llc_estimate()
+
+    def on_checkpoint(self, ckpt_path: str, stage: str) -> None:
+        """Record checkpoint metadata for post-hoc sweeps."""
+
+        info = {
+            "ts": time.time(),
+            "step": self.global_step,
+            "stage": stage,
+            "ckpt_path": ckpt_path,
+            "param_stats": self._param_space_summary(topk=self.cfg.spectral_topk),
+        }
+        self._append_manifest(info)
+
+    # ---------- post-hoc (run in separate scripts) ----------
+    @torch.inference_mode()
+    def export_activations(self, dataloader: Iterable, layers: Iterable[str], out_path: str) -> None:
+        """Export activation snapshots for later interpretability analysis."""
+
+        records: List[Dict[str, Any]] = []
+        hooks: List[Any] = []
+
+        def _hook(name: str):
+            def fn(_module: nn.Module, _inp: tuple, out: torch.Tensor) -> None:
+                sample = out[:1].detach().cpu().numpy()
+                records.append(
+                    {
+                        "layer": name,
+                        "step": self.global_step,
+                        "shape": tuple(out.shape),
+                        "sample": sample,
+                    }
+                )
+
+            return fn
+
+        try:
+            device = next(self.model.parameters()).device
+            for name, module in self.model.named_modules():
+                if name in layers:
+                    hooks.append(module.register_forward_hook(_hook(name)))
+            for batch in dataloader:
+                batch = {k: v.to(device) if isinstance(v, torch.Tensor) else v for k, v in batch.items()}
+                _ = self.model(**batch)
+        finally:
+            for hook in hooks:
+                hook.remove()
+
+        out_file = pathlib.Path(out_path)
+        out_file.parent.mkdir(parents=True, exist_ok=True)
+        df = pd.DataFrame(records)
+        df.to_parquet(out_file)
+
+    # ---------- internals ----------
+    def _grad_global_norm(self) -> float:
+        total = 0.0
+        for param in self.model.parameters():
+            if param.grad is not None:
+                total += param.grad.data.float().pow(2).sum().item()
+        return math.sqrt(total) if total > 0 else 0.0
+
+    def _weight_global_norm(self) -> float:
+        total = 0.0
+        for param in self.model.parameters():
+            total += param.data.float().pow(2).sum().item()
+        return math.sqrt(total)
+
+    def _get_momentum_stat(self) -> float:
+        for group in self.optimizer.param_groups:
+            momentum = group.get("betas")
+            if momentum:
+                return float(momentum[0])
+            momentum = group.get("momentum")
+            if momentum:
+                return float(momentum)
+        return float("nan")
+
+    def _param_space_summary(self, topk: int = 8) -> Dict[str, Any]:
+        layers: List[Dict[str, Any]] = []
+        flat_params: List[torch.Tensor] = []
+        for name, module in self.model.named_modules():
+            if hasattr(module, "weight") and isinstance(module.weight, torch.Tensor):
+                weight = module.weight.detach()
+                norm = float(weight.norm().item())
+                sparsity = float((weight == 0).float().mean().item())
+                sv1 = self._spectral_proxy(weight, power_iter=2)
+                layers.append({"name": name, "norm": norm, "sv1_proxy": sv1, "sparsity": sparsity, "shape": tuple(weight.shape)})
+                flat_params.append(weight.flatten().float().cpu())
+        flat = torch.cat(flat_params) if flat_params else torch.tensor([], dtype=torch.float32)
+        cosine = float("nan")
+        if self._prev_flat_params is not None and flat.numel() == self._prev_flat_params.numel():
+            cosine = torch.nn.functional.cosine_similarity(flat, self._prev_flat_params, dim=0).item()
+        self._prev_flat_params = flat
+        return {"layers": layers, "cosine_drift": cosine, "num_layers": len(layers)}
+
+    def _spectral_proxy(self, weight: torch.Tensor, power_iter: int = 2) -> float:
+        if weight.ndim > 2:
+            w_mat = weight.flatten(1)
+        else:
+            w_mat = weight
+        device = w_mat.device
+        vec = torch.randn(w_mat.shape[-1], device=device)
+        for _ in range(power_iter):
+            vec = torch.mv(w_mat.t(), torch.mv(w_mat, vec))
+            vec = vec / (vec.norm() + 1e-12)
+        sv = torch.mv(w_mat, vec)
+        return float(sv.norm().item())
+
+    def _log_curvature_proxies(self) -> None:
+        if self._curvature_closure is None:
+            self._log_row({"step": self.global_step, "warn/curvature": "closure_not_registered"})
+            return
+        params = [p for p in self.model.parameters() if p.requires_grad]
+        if not params:
+            return
+        estimates = []
+        try:
+            for _ in range(self.cfg.hutchinson_vecs):
+                loss = self._curvature_closure()
+                grads = torch.autograd.grad(loss, params, create_graph=True, retain_graph=True)
+                vectors = []
+                for grad in grads:
+                    v = torch.randint_like(grad, low=0, high=2)
+                    v = (v * 2 - 1).to(dtype=grad.dtype)
+                    vectors.append(v)
+                inner = torch.zeros((), device=params[0].device)
+                for g, v in zip(grads, vectors):
+                    inner = inner + (g * v).sum()
+                hvps = torch.autograd.grad(inner, params, retain_graph=False)
+                trace = sum((h * v).sum().item() for h, v in zip(hvps, vectors))
+                estimates.append(trace)
+            trace_est = float(sum(estimates) / max(1, len(estimates)))
+            self._log_row({"step": self.global_step, "curvature/hutchinson_trace": trace_est})
+        except Exception as exc:  # pragma: no cover - protective
+            self._log_row({"step": self.global_step, "warn/curvature_error": str(exc)})
+
+    def _log_llc_estimate(self) -> None:
+        if not DEVINTERP_AVAILABLE:
+            self._log_row({"step": self.global_step, "warn/llc_missing": True})
+            return
+        if self._llc_loader is None:
+            self._log_row({"step": self.global_step, "warn/llc_loader_missing": True})
+            return
+        try:
+            estimator = LLCEstimator(nbeta=self.cfg.llc_nbeta)
+            sampler = SGLD(lr=self.cfg.llc_sampler_lr)
+            devinterp_sample(
+                model=self.model,
+                data_loader=self._llc_loader,
+                sampler=sampler,
+                max_steps=self.cfg.llc_max_steps,
+                batch_size=self.cfg.llc_batch_size,
+                callbacks=[estimator],
+                **self._llc_sampler_kwargs,
+            )
+            if hasattr(estimator, "summary"):
+                results = estimator.summary()
+            elif hasattr(estimator, "get_results"):
+                results = estimator.get_results()
+            else:
+                results = {"mean": float("nan")}
+            formatted = {f"llc/{k}": self._to_float(v) for k, v in results.items()}
+            formatted["step"] = self.global_step
+            self._log_row(formatted)
+        except Exception as exc:  # pragma: no cover - optional path
+            self._log_row({"step": self.global_step, "warn/llc_error": str(exc)})
+
+    def _init_manifest(self) -> None:
+        path = self.root / self.cfg.manifest_name
+        if not path.exists():
+            pd.DataFrame(columns=["ts", "step", "stage", "ckpt_path", "param_stats"]).to_parquet(path)
+
+    def _append_manifest(self, record: Dict[str, Any]) -> None:
+        path = self.root / self.cfg.manifest_name
+        df_old = pd.read_parquet(path) if path.exists() else pd.DataFrame()
+        df_new = pd.concat([df_old, pd.DataFrame([record])], ignore_index=True)
+        df_new.to_parquet(path)
+
+    def _log_row(self, row: Dict[str, Any]) -> None:
+        for module in self._modules:
+            try:
+                extra = module(row, self.global_step)
+                if extra:
+                    row.update(extra)
+            except Exception as exc:  # pragma: no cover - plugin errors shouldn't crash training
+                row[f"warn/plugin/{module.__class__.__name__}"] = str(exc)
+        self._buffer.append(row)
+        if self._tb:
+            for key, value in row.items():
+                if isinstance(value, bool):
+                    continue
+                if isinstance(value, (int, float)) and not math.isnan(float(value)):
+                    self._tb.add_scalar(key, float(value), self.global_step)
+        if len(self._buffer) >= self.cfg.parquet_rollover_rows or (self.global_step % self.cfg.log_every == 0):
+            self._flush()
+
+    def _flush(self) -> None:
+        if not self._buffer:
+            return
+        df = pd.DataFrame(self._buffer)
+        if self._parquet_path.exists():
+            df_prev = pd.read_parquet(self._parquet_path)
+            df = pd.concat([df_prev, df], ignore_index=True)
+        df.to_parquet(self._parquet_path)
+        self._buffer.clear()
+
+    def finalize(self) -> None:
+        self._flush()
+        if self._tb:
+            self._tb.flush()
+            self._tb.close()
+
+    def __del__(self) -> None:  # pragma: no cover - best effort
+        try:
+            self.finalize()
+        except Exception:
+            pass
+
+    @staticmethod
+    def _to_float(value: Any) -> float:
+        try:
+            return float(value)
+        except Exception:
+            return float("nan")
+
+    @staticmethod
+    def _safe_ratio(a: float, b: float) -> float:
+        return a / b if b not in {0.0, 0} else float("inf")
+
+
+__all__ = ["TrainingDevMetrics", "MetricConfig", "MetricModule", "DEVINTERP_AVAILABLE"]

--- a/paligemma2/__init__.py
+++ b/paligemma2/__init__.py
@@ -1,0 +1,12 @@
+"""PaliGemma 2 training utilities."""
+
+from .config import TrainingStageConfig, StageSchedule, ModelAssetConfig
+from .modeling import build_paligemma2_model, load_paligemma2_checkpoint
+
+__all__ = [
+    "TrainingStageConfig",
+    "StageSchedule",
+    "ModelAssetConfig",
+    "build_paligemma2_model",
+    "load_paligemma2_checkpoint",
+]

--- a/paligemma2/config.py
+++ b/paligemma2/config.py
@@ -1,0 +1,124 @@
+"""Configuration primitives for PaliGemma 2 reproduction."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional
+
+
+@dataclass
+class ModelAssetConfig:
+    """Describe a released PaliGemma 2 asset."""
+
+    model_size: str  # e.g. "3b", "10b", "28b"
+    resolution: int  # input resolution (224, 448, 896)
+    tag: str  # huggingface or kaggle identifier
+    file_name: str  # expected file name for weight archive
+    sha256: Optional[str] = None
+    description: str = ""
+
+
+@dataclass
+class TrainingStageConfig:
+    """Hyperparameters for a coarse training stage."""
+
+    name: str
+    resolution: int
+    num_examples: int
+    batch_size: int
+    max_steps: int
+    learning_rate: float
+    weight_decay: float
+    warmup_steps: int
+    task_weights: Dict[str, float]
+    sequence_length: int
+    notes: str = ""
+
+
+@dataclass
+class StageSchedule:
+    """Container capturing the three-stage curriculum described in the report."""
+
+    stages: List[TrainingStageConfig] = field(default_factory=list)
+
+    @classmethod
+    def default_schedule(cls) -> "StageSchedule":
+        """Return a coarse approximation of the public three-stage curriculum."""
+        stages = [
+            TrainingStageConfig(
+                name="stage1",
+                resolution=224,
+                num_examples=1_000_000_000,
+                batch_size=4096,
+                max_steps=250_000,
+                learning_rate=3e-4,
+                weight_decay=0.1,
+                warmup_steps=2_000,
+                task_weights={
+                    "captioning": 0.4,
+                    "ocr": 0.3,
+                    "grounded_captioning": 0.2,
+                    "vision_language": 0.1,
+                },
+                sequence_length=1024,
+                notes="Joint pre-training with mixed tasks at 224px",
+            ),
+            TrainingStageConfig(
+                name="stage2a",
+                resolution=448,
+                num_examples=50_000_000,
+                batch_size=2048,
+                max_steps=20_000,
+                learning_rate=2e-4,
+                weight_decay=0.05,
+                warmup_steps=1_000,
+                task_weights={
+                    "captioning": 0.3,
+                    "ocr": 0.4,
+                    "grounded_captioning": 0.2,
+                    "vision_language": 0.1,
+                },
+                sequence_length=1536,
+                notes="Resolution upshift to 448px with OCR emphasis",
+            ),
+            TrainingStageConfig(
+                name="stage2b",
+                resolution=896,
+                num_examples=10_000_000,
+                batch_size=1024,
+                max_steps=10_000,
+                learning_rate=1.5e-4,
+                weight_decay=0.05,
+                warmup_steps=500,
+                task_weights={
+                    "captioning": 0.2,
+                    "ocr": 0.45,
+                    "grounded_captioning": 0.25,
+                    "vision_language": 0.1,
+                },
+                sequence_length=2048,
+                notes="High-resolution phase with long-sequence decoding",
+            ),
+            TrainingStageConfig(
+                name="stage3",
+                resolution=896,
+                num_examples=5_000_000,
+                batch_size=512,
+                max_steps=5_000,
+                learning_rate=1e-4,
+                weight_decay=0.02,
+                warmup_steps=500,
+                task_weights={
+                    "captioning": 0.25,
+                    "ocr": 0.35,
+                    "grounded_captioning": 0.25,
+                    "vision_language": 0.15,
+                },
+                sequence_length=2048,
+                notes="Per-task fine-tuning sweeps; adjust LR per model scale",
+            ),
+        ]
+        return cls(stages=stages)
+
+    def to_dict(self) -> List[Dict[str, object]]:
+        """Serialise the schedule to a list of dictionaries for logging."""
+        return [vars(stage) for stage in self.stages]

--- a/paligemma2/modeling.py
+++ b/paligemma2/modeling.py
@@ -1,0 +1,188 @@
+"""Model assembly utilities for PaliGemma 2 reproduction."""
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Dict, Optional
+
+import torch
+from torch import nn
+
+try:
+    from transformers import AutoModelForCausalLM, SiglipVisionModel
+except Exception as exc:  # pragma: no cover - import error surfaces at runtime
+    raise ImportError(
+        "transformers>=4.41.0 is required to construct the PaliGemma 2 model"
+    ) from exc
+
+from .config import ModelAssetConfig
+
+LOGGER = logging.getLogger(__name__)
+
+
+PALIGEMMA2_ASSETS: Dict[str, ModelAssetConfig] = {
+    "3b-224": ModelAssetConfig(
+        model_size="3b",
+        resolution=224,
+        tag="google/paligemma2-3b-pt-224",
+        file_name="pytorch_model.bin",
+        description="Base 3B checkpoint pretrained at 224px",
+    ),
+    "3b-448": ModelAssetConfig(
+        model_size="3b",
+        resolution=448,
+        tag="google/paligemma2-3b-pt-448",
+        file_name="pytorch_model.bin",
+        description="Resolution-upshifted 3B checkpoint",
+    ),
+    "3b-896": ModelAssetConfig(
+        model_size="3b",
+        resolution=896,
+        tag="google/paligemma2-3b-pt-896",
+        file_name="pytorch_model.bin",
+        description="High-resolution 3B checkpoint",
+    ),
+    "10b-224": ModelAssetConfig(
+        model_size="10b",
+        resolution=224,
+        tag="google/paligemma2-10b-pt-224",
+        file_name="pytorch_model.bin",
+        description="Base 10B checkpoint",
+    ),
+    "10b-448": ModelAssetConfig(
+        model_size="10b",
+        resolution=448,
+        tag="google/paligemma2-10b-pt-448",
+        file_name="pytorch_model.bin",
+        description="Intermediate resolution 10B",
+    ),
+    "10b-896": ModelAssetConfig(
+        model_size="10b",
+        resolution=896,
+        tag="google/paligemma2-10b-pt-896",
+        file_name="pytorch_model.bin",
+        description="High-resolution 10B",
+    ),
+    "28b-224": ModelAssetConfig(
+        model_size="28b",
+        resolution=224,
+        tag="google/paligemma2-28b-pt-224",
+        file_name="pytorch_model.bin",
+        description="Base 28B checkpoint",
+    ),
+    "28b-448": ModelAssetConfig(
+        model_size="28b",
+        resolution=448,
+        tag="google/paligemma2-28b-pt-448",
+        file_name="pytorch_model.bin",
+        description="Intermediate resolution 28B",
+    ),
+    "28b-896": ModelAssetConfig(
+        model_size="28b",
+        resolution=896,
+        tag="google/paligemma2-28b-pt-896",
+        file_name="pytorch_model.bin",
+        description="High-resolution 28B",
+    ),
+}
+
+SIGLIP_SO400M_REPO = "google/siglip-so400m-patch14-384"
+GEMMA2_TEXT_REPOS = {
+    "3b": "google/gemma-2-2b-it",
+    "10b": "google/gemma-2-9b-it",
+    "28b": "google/gemma-2-27b-it",
+}
+
+
+@dataclass
+class PaliGemma2Config:
+    """Configuration for the composed multimodal model."""
+
+    model_size: str
+    resolution: int
+    vision_repo: str = SIGLIP_SO400M_REPO
+    text_repo: Optional[str] = None
+    use_lora: bool = False
+    freeze_vision: bool = False
+    freeze_text: bool = False
+
+
+class PaliGemma2ForConditionalGeneration(nn.Module):
+    """Minimal SigLIP + Gemma 2 fusion resembling PaliGemma 2."""
+
+    def __init__(self, vision_model: SiglipVisionModel, text_model: AutoModelForCausalLM, hidden_dim: int):
+        super().__init__()
+        self.vision_model = vision_model
+        self.text_model = text_model
+        self.vision_projector = nn.Linear(vision_model.config.hidden_size, hidden_dim)
+        nn.init.normal_(self.vision_projector.weight, std=0.02)
+        nn.init.zeros_(self.vision_projector.bias)
+
+    def forward(
+        self,
+        pixel_values: torch.Tensor,
+        input_ids: torch.Tensor,
+        attention_mask: Optional[torch.Tensor] = None,
+        labels: Optional[torch.Tensor] = None,
+        prepend_vision_token: bool = True,
+        **kwargs,
+    ) -> torch.Tensor:
+        """Run a forward pass through the multimodal model."""
+
+        vision_hidden = self.vision_model(pixel_values=pixel_values, output_hidden_states=True).last_hidden_state
+        pooled = vision_hidden.mean(dim=1)
+        vision_embedding = self.vision_projector(pooled)
+
+        text_inputs = self.text_model.get_input_embeddings()(input_ids)
+        if prepend_vision_token:
+            vis_token = vision_embedding.unsqueeze(1)
+            text_inputs = torch.cat([vis_token, text_inputs], dim=1)
+            if attention_mask is not None:
+                prefix_mask = torch.ones(attention_mask.size(0), 1, device=attention_mask.device, dtype=attention_mask.dtype)
+                attention_mask = torch.cat([prefix_mask, attention_mask], dim=1)
+            if labels is not None:
+                pad_value = -100
+                labels = torch.cat([torch.full((labels.size(0), 1), pad_value, dtype=labels.dtype, device=labels.device), labels], dim=1)
+
+        outputs = self.text_model(
+            inputs_embeds=text_inputs,
+            attention_mask=attention_mask,
+            labels=labels,
+            **kwargs,
+        )
+        return outputs
+
+
+def build_paligemma2_model(cfg: PaliGemma2Config, device: Optional[str] = None, dtype: torch.dtype = torch.bfloat16) -> PaliGemma2ForConditionalGeneration:
+    """Instantiate the multimodal model with released checkpoints."""
+
+    text_repo = cfg.text_repo or GEMMA2_TEXT_REPOS.get(cfg.model_size)
+    if text_repo is None:
+        raise ValueError(f"No Gemma 2 text repo mapping for model size {cfg.model_size}")
+
+    LOGGER.info("Loading SigLIP vision tower from %s", cfg.vision_repo)
+    vision_model = SiglipVisionModel.from_pretrained(cfg.vision_repo, torch_dtype=dtype)
+    LOGGER.info("Loading Gemma text decoder from %s", text_repo)
+    text_model = AutoModelForCausalLM.from_pretrained(text_repo, torch_dtype=dtype)
+
+    if cfg.freeze_vision:
+        for p in vision_model.parameters():
+            p.requires_grad = False
+    if cfg.freeze_text:
+        for p in text_model.parameters():
+            p.requires_grad = False
+
+    model = PaliGemma2ForConditionalGeneration(vision_model, text_model, hidden_dim=text_model.config.hidden_size)
+    if device:
+        model.to(device)
+    return model
+
+
+def load_paligemma2_checkpoint(model: nn.Module, checkpoint_path: str, strict: bool = True) -> Dict[str, torch.Tensor]:
+    """Load a checkpoint produced by this repo's trainer."""
+
+    state = torch.load(checkpoint_path, map_location="cpu")
+    missing, unexpected = model.load_state_dict(state["model"], strict=strict)
+    if missing or unexpected:
+        LOGGER.warning("Missing keys: %s | Unexpected keys: %s", missing, unexpected)
+    return state

--- a/paligemma2/training/pipeline.py
+++ b/paligemma2/training/pipeline.py
@@ -1,0 +1,190 @@
+"""Training pipeline approximating the PaliGemma 2 three-stage curriculum."""
+from __future__ import annotations
+
+import contextlib
+import logging
+import pathlib
+import random
+from dataclasses import dataclass
+from typing import Dict, Iterator, List, Optional, Tuple
+
+import torch
+from torch import nn
+from torch.optim import Optimizer
+from torch.optim.lr_scheduler import LambdaLR
+from torch.utils.data import DataLoader
+
+from ..config import StageSchedule, TrainingStageConfig
+from ..data.registry import REGISTRY, register_stub_tasks
+from metrics.training_dev_metrics import TrainingDevMetrics
+
+LOGGER = logging.getLogger(__name__)
+
+
+@dataclass
+class TrainerConfig:
+    """Configuration knobs for the trainer."""
+
+    device: str = "cuda"
+    precision: torch.dtype = torch.bfloat16
+    grad_clip: float = 1.0
+    save_dir: str = "outputs"
+    save_every: int = 500
+    keep_last: int = 5
+    use_fsdp: bool = False
+    zero_stage: int = 0
+    activation_checkpointing: bool = False
+    resume_from: Optional[str] = None
+    enable_ema: bool = False
+    ema_decay: float = 0.9999
+
+
+class CheckpointManager:
+    """Persist high-frequency checkpoints with metadata."""
+
+    def __init__(self, save_dir: str, keep_last: int = 5) -> None:
+        self.root = pathlib.Path(save_dir)
+        self.root.mkdir(parents=True, exist_ok=True)
+        self.keep_last = keep_last
+        self._checkpoints: List[pathlib.Path] = []
+
+    def save(self, step: int, stage: str, model: nn.Module, optimizer: Optimizer, scheduler: Optional[LambdaLR], metrics: TrainingDevMetrics, ema_state: Optional[Dict[str, torch.Tensor]] = None) -> pathlib.Path:
+        ckpt_path = self.root / f"ckpt_step{step:08d}.pt"
+        state = {
+            "step": step,
+            "stage": stage,
+            "model": model.state_dict(),
+            "optimizer": optimizer.state_dict(),
+            "scheduler": scheduler.state_dict() if scheduler else None,
+            "rng_state": torch.get_rng_state(),
+        }
+        if ema_state:
+            state["ema"] = ema_state
+        torch.save(state, ckpt_path)
+        self._checkpoints.append(ckpt_path)
+        self._checkpoints = self._checkpoints[-self.keep_last :]
+        metrics.on_checkpoint(str(ckpt_path), stage=stage)
+        return ckpt_path
+
+
+class WeightedMultiTaskIterator:
+    """Yield batches by sampling tasks proportionally to mixture weights."""
+
+    def __init__(self, loaders: Dict[str, DataLoader], weights: Dict[str, float]):
+        self.loaders = loaders
+        self._iters: Dict[str, Iterator] = {}
+        total = sum(weights.values())
+        if total <= 0:
+            raise ValueError("Task weights must be positive")
+        self.probs = {name: weight / total for name, weight in weights.items()}
+
+    def __iter__(self) -> Iterator[Tuple[str, Dict[str, torch.Tensor]]]:
+        while True:
+            task = random.choices(list(self.probs.keys()), weights=list(self.probs.values()))[0]
+            batch = self._next_batch(task)
+            yield task, batch
+
+    def _next_batch(self, name: str):
+        if name not in self._iters:
+            self._iters[name] = iter(self.loaders[name])
+        try:
+            return next(self._iters[name])
+        except StopIteration:
+            self._iters[name] = iter(self.loaders[name])
+            return next(self._iters[name])
+
+
+class Trainer:
+    """Minimal trainer supporting the required curriculum and metrics."""
+
+    def __init__(
+        self,
+        model: nn.Module,
+        optimizer: Optimizer,
+        schedule: StageSchedule,
+        metrics: TrainingDevMetrics,
+        cfg: TrainerConfig,
+    ) -> None:
+        self.model = model
+        self.optimizer = optimizer
+        self.schedule = schedule
+        self.metrics = metrics
+        self.cfg = cfg
+        self.device = torch.device(cfg.device)
+        self.model.to(self.device)
+        use_scaler = self.device.type == "cuda" and cfg.precision == torch.float16
+        self.scaler = torch.cuda.amp.GradScaler(enabled=use_scaler)
+        self.checkpoints = CheckpointManager(cfg.save_dir, cfg.keep_last)
+        if not REGISTRY.names():
+            register_stub_tasks()
+
+    def _build_scheduler(self, stage_cfg: TrainingStageConfig, total_steps: int) -> LambdaLR:
+        def lr_lambda(step: int) -> float:
+            if step < stage_cfg.warmup_steps:
+                return step / max(1, stage_cfg.warmup_steps)
+            progress = (step - stage_cfg.warmup_steps) / max(1, total_steps - stage_cfg.warmup_steps)
+            return max(0.0, 1.0 - progress)
+
+        return LambdaLR(self.optimizer, lr_lambda)
+
+    def run(self) -> None:
+        for stage_cfg in self.schedule.stages:
+            LOGGER.info("Starting stage %s", stage_cfg.name)
+            loaders = REGISTRY.loaders(stage_cfg.task_weights, stage_cfg.resolution, stage_cfg.batch_size)
+            iterator = iter(WeightedMultiTaskIterator(loaders, stage_cfg.task_weights))
+            scheduler = self._build_scheduler(stage_cfg, stage_cfg.max_steps)
+            if loaders:
+                # Use the first loader as LLC reference if requested.
+                first_loader = next(iter(loaders.values()))
+                self.metrics.register_llc_inputs(first_loader)
+            for step in range(stage_cfg.max_steps):
+                task_name, batch = next(iterator)
+                batch = {k: v.to(self.device) if isinstance(v, torch.Tensor) else v for k, v in batch.items()}
+                autocast_ctx = (
+                    torch.autocast(device_type=self.device.type, dtype=self.cfg.precision)
+                    if self.device.type in {"cuda", "xpu"}
+                    else contextlib.nullcontext()
+                )
+                with autocast_ctx:
+                    outputs = self.model(**batch)
+                    loss = outputs.loss if hasattr(outputs, "loss") else outputs[0]
+                self.optimizer.zero_grad()
+                if self.scaler.is_enabled():
+                    self.scaler.scale(loss).backward()
+                    self.scaler.unscale_(self.optimizer)
+                else:
+                    loss.backward()
+                if self.cfg.grad_clip:
+                    torch.nn.utils.clip_grad_norm_(self.model.parameters(), self.cfg.grad_clip)
+                if self.scaler.is_enabled():
+                    self.scaler.step(self.optimizer)
+                    self.scaler.update()
+                else:
+                    self.optimizer.step()
+                scheduler.step()
+
+                lr = self.optimizer.param_groups[0]["lr"]
+                self.metrics.on_step_end(loss=float(loss.detach().cpu()), batch_size=batch["input_ids"].size(0), lr=lr, task=task_name)
+                self.metrics.register_curvature_closure(lambda batch=batch: self._recompute_loss(batch))
+
+                if self.metrics.global_step % self.cfg.save_every == 0:
+                    self.checkpoints.save(self.metrics.global_step, stage_cfg.name, self.model, self.optimizer, scheduler, self.metrics)
+
+            LOGGER.info("Completed stage %s", stage_cfg.name)
+
+    def _recompute_loss(self, batch: Dict[str, torch.Tensor]) -> torch.Tensor:
+        clone = {}
+        for key, value in batch.items():
+            if isinstance(value, torch.Tensor):
+                clone[key] = value.detach().clone().requires_grad_(value.requires_grad)
+            else:
+                clone[key] = value
+        outputs = self.model(**clone)
+        return outputs.loss if hasattr(outputs, "loss") else outputs[0]
+
+
+__all__ = [
+    "Trainer",
+    "TrainerConfig",
+    "CheckpointManager",
+]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+torch>=2.2
+transformers>=4.41
+huggingface_hub>=0.21
+pandas>=2.1
+pyarrow>=15.0
+tensorboard>=2.14

--- a/scripts/checkpoint_indexer.py
+++ b/scripts/checkpoint_indexer.py
@@ -1,0 +1,37 @@
+"""Build lightweight checkpoint indices from the training manifest."""
+from __future__ import annotations
+
+import argparse
+import json
+import pathlib
+from typing import Dict, List
+
+import pandas as pd
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--log-dir", type=pathlib.Path, required=True)
+    parser.add_argument("--out", type=pathlib.Path, default=None)
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    manifest_path = args.log_dir / "CHECKPOINT_MANIFEST.parquet"
+    if not manifest_path.exists():
+        raise FileNotFoundError(f"Manifest {manifest_path} not found")
+    df = pd.read_parquet(manifest_path)
+    summary = {
+        "num_checkpoints": int(len(df)),
+        "stages": df.groupby("stage")["step"].agg(["min", "max", "count"]).reset_index().to_dict(orient="records"),
+    }
+    if args.out:
+        args.out.parent.mkdir(parents=True, exist_ok=True)
+        args.out.write_text(json.dumps(summary, indent=2))
+    else:
+        print(json.dumps(summary, indent=2))
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI
+    main()

--- a/scripts/download_assets.py
+++ b/scripts/download_assets.py
@@ -1,0 +1,84 @@
+"""Download released PaliGemma 2 checkpoints and related docs."""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import pathlib
+from typing import Iterable, Optional
+
+from huggingface_hub import HfApi, hf_hub_download
+
+from paligemma2.modeling import PALIGEMMA2_ASSETS
+
+
+def list_assets() -> list[dict[str, str]]:
+    return [
+        {
+            "key": key,
+            "model_size": asset.model_size,
+            "resolution": asset.resolution,
+            "repo_id": asset.tag,
+            "file": asset.file_name,
+            "sha256": asset.sha256 or "unknown",
+        }
+        for key, asset in PALIGEMMA2_ASSETS.items()
+    ]
+
+
+def compute_sha256(path: pathlib.Path) -> str:
+    h = hashlib.sha256()
+    with path.open("rb") as f:
+        for chunk in iter(lambda: f.read(1024 * 1024), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def download_asset(key: str, output_dir: pathlib.Path, verify: bool = True) -> pathlib.Path:
+    if key not in PALIGEMMA2_ASSETS:
+        raise KeyError(f"Unknown asset key {key}. Use --list to inspect available keys.")
+    asset = PALIGEMMA2_ASSETS[key]
+    output_dir.mkdir(parents=True, exist_ok=True)
+    local_path = hf_hub_download(repo_id=asset.tag, filename=asset.file_name, local_dir=str(output_dir))
+    if verify and asset.sha256:
+        digest = compute_sha256(pathlib.Path(local_path))
+        if digest != asset.sha256:
+            raise RuntimeError(f"Checksum mismatch for {local_path}: expected {asset.sha256} got {digest}")
+    return pathlib.Path(local_path)
+
+
+def fetch_model_card(repo_id: str) -> dict[str, str]:
+    api = HfApi()
+    card = api.model_card(repo_id)
+    return {
+        "repo_id": repo_id,
+        "card": card.content,
+    }
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--output-dir", type=pathlib.Path, default=pathlib.Path("weights"))
+    parser.add_argument("--key", type=str, help="Asset key (e.g. 3b-224). Use --list to view options.")
+    parser.add_argument("--skip-verify", action="store_true")
+    parser.add_argument("--dump-card", action="store_true", help="Also download the model card JSON.")
+    parser.add_argument("--list", action="store_true", help="List assets and exit.")
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    if args.list:
+        print(json.dumps(list_assets(), indent=2))
+        return
+    path = download_asset(args.key, args.output_dir, verify=not args.skip_verify)
+    print(f"Downloaded {args.key} to {path}")
+    if args.dump_card:
+        card = fetch_model_card(PALIGEMMA2_ASSETS[args.key].tag)
+        card_path = args.output_dir / f"{args.key}_card.json"
+        card_path.write_text(json.dumps(card, indent=2))
+        print(f"Saved model card to {card_path}")
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry
+    main()

--- a/scripts/eval.py
+++ b/scripts/eval.py
@@ -1,0 +1,54 @@
+"""Evaluate a saved PaliGemma 2 checkpoint on registered tasks."""
+from __future__ import annotations
+
+import argparse
+import json
+import pathlib
+from typing import Dict
+
+import torch
+
+from paligemma2.data.registry import REGISTRY, register_stub_tasks
+from paligemma2.modeling import PaliGemma2Config, build_paligemma2_model, load_paligemma2_checkpoint
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--checkpoint", type=pathlib.Path, required=True)
+    parser.add_argument("--model-size", default="3b")
+    parser.add_argument("--device", default="cuda")
+    parser.add_argument("--resolution", type=int, default=224)
+    parser.add_argument("--limit", type=int, default=100, help="Maximum batches per task.")
+    return parser.parse_args()
+
+
+def evaluate(model: torch.nn.Module, loaders: Dict[str, torch.utils.data.DataLoader], device: str, limit: int) -> Dict[str, float]:
+    results: Dict[str, float] = {}
+    model.eval()
+    with torch.inference_mode():
+        for task, loader in loaders.items():
+            losses = []
+            for idx, batch in enumerate(loader):
+                batch = {k: v.to(device) if isinstance(v, torch.Tensor) else v for k, v in batch.items()}
+                outputs = model(**batch)
+                loss = outputs.loss if hasattr(outputs, "loss") else outputs[0]
+                losses.append(float(loss.detach().cpu()))
+                if idx + 1 >= limit:
+                    break
+            results[f"{task}/loss"] = sum(losses) / max(1, len(losses))
+    return results
+
+
+def main() -> None:
+    args = parse_args()
+    model = build_paligemma2_model(PaliGemma2Config(model_size=args.model_size, resolution=args.resolution), device=args.device)
+    load_paligemma2_checkpoint(model, str(args.checkpoint))
+    if not REGISTRY.names():
+        register_stub_tasks()
+    loaders = {name: spec.loader(args.resolution, batch_size=8) for name, spec in ((name, REGISTRY.get(name)) for name in REGISTRY.names())}
+    metrics = evaluate(model, loaders, args.device, args.limit)
+    print(json.dumps({"checkpoint": str(args.checkpoint), "metrics": metrics}, indent=2))
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI
+    main()

--- a/scripts/export_activations.py
+++ b/scripts/export_activations.py
@@ -1,0 +1,46 @@
+"""Export activation snapshots from a checkpoint for post-hoc analysis."""
+from __future__ import annotations
+
+import argparse
+import pathlib
+from typing import Iterable
+
+import torch
+
+from metrics.training_dev_metrics import MetricConfig, TrainingDevMetrics
+from paligemma2.data.registry import REGISTRY, register_stub_tasks
+from paligemma2.modeling import PaliGemma2Config, build_paligemma2_model, load_paligemma2_checkpoint
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--checkpoint", type=pathlib.Path, required=True)
+    parser.add_argument("--out", type=pathlib.Path, required=True)
+    parser.add_argument("--layers", nargs="+", required=True, help="Layer names to hook.")
+    parser.add_argument("--model-size", default="3b")
+    parser.add_argument("--resolution", type=int, default=224)
+    parser.add_argument("--device", default="cuda")
+    parser.add_argument("--batches", type=int, default=10)
+    return parser.parse_args()
+
+
+def build_loader(resolution: int) -> Iterable:
+    if not REGISTRY.names():
+        register_stub_tasks()
+    return REGISTRY.get("captioning").loader(resolution, batch_size=4)
+
+
+def main() -> None:
+    args = parse_args()
+    model = build_paligemma2_model(PaliGemma2Config(model_size=args.model_size, resolution=args.resolution), device=args.device)
+    load_paligemma2_checkpoint(model, str(args.checkpoint))
+    dummy_optimizer = torch.optim.AdamW(model.parameters(), lr=1e-4)
+    metrics = TrainingDevMetrics(MetricConfig(log_dir=args.out.parent.as_posix()), model=model, optimizer=dummy_optimizer)
+    loader = build_loader(args.resolution)
+    iterator = iter(loader)
+    sliced = (batch for _, batch in zip(range(args.batches), iterator))
+    metrics.export_activations(sliced, layers=args.layers, out_path=str(args.out))
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry
+    main()

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -1,0 +1,61 @@
+"""Entry point for reproducing the three-stage PaliGemma 2 curriculum."""
+from __future__ import annotations
+
+import argparse
+import pathlib
+
+import torch
+
+from metrics.training_dev_metrics import MetricConfig, TrainingDevMetrics
+from paligemma2.config import StageSchedule
+from paligemma2.modeling import PaliGemma2Config, build_paligemma2_model
+from paligemma2.training.pipeline import Trainer, TrainerConfig
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--model-size", default="3b", choices=["3b", "10b", "28b"])
+    parser.add_argument("--log-dir", type=pathlib.Path, default=pathlib.Path("runs"))
+    parser.add_argument("--tb-dir", type=pathlib.Path, default=None)
+    parser.add_argument("--device", default="cuda")
+    parser.add_argument("--precision", default="bf16", choices=["bf16", "fp16", "fp32"])
+    parser.add_argument("--lr", type=float, default=2e-4)
+    parser.add_argument("--weight-decay", type=float, default=0.05)
+    parser.add_argument("--save-dir", type=pathlib.Path, default=pathlib.Path("checkpoints"))
+    parser.add_argument("--save-every", type=int, default=200)
+    parser.add_argument("--max-steps", type=int, default=None, help="Optional cap on steps per stage for smoke tests.")
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    dtype = {
+        "bf16": torch.bfloat16,
+        "fp16": torch.float16,
+        "fp32": torch.float32,
+    }[args.precision]
+
+    schedule = StageSchedule.default_schedule()
+    if args.max_steps is not None:
+        for stage in schedule.stages:
+            stage.max_steps = min(stage.max_steps, args.max_steps)
+
+    model = build_paligemma2_model(PaliGemma2Config(model_size=args.model_size, resolution=schedule.stages[0].resolution), dtype=dtype, device=args.device)
+    optimizer = torch.optim.AdamW(model.parameters(), lr=args.lr, weight_decay=args.weight_decay)
+
+    metric_cfg = MetricConfig(log_dir=str(args.log_dir), tb_dir=str(args.tb_dir) if args.tb_dir else None)
+    metrics = TrainingDevMetrics(metric_cfg, model=model, optimizer=optimizer)
+
+    trainer_cfg = TrainerConfig(
+        device=args.device,
+        precision=dtype,
+        save_dir=str(args.save_dir),
+        save_every=args.save_every,
+    )
+    trainer = Trainer(model=model, optimizer=optimizer, schedule=schedule, metrics=metrics, cfg=trainer_cfg)
+    trainer.run()
+    metrics.finalize()
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry
+    main()

--- a/scripts/verify_assets.py
+++ b/scripts/verify_assets.py
@@ -1,0 +1,38 @@
+"""Verify availability of PaliGemma 2 assets and documentation."""
+from __future__ import annotations
+
+import json
+from typing import Dict
+
+from huggingface_hub import HfApi
+
+from paligemma2.modeling import PALIGEMMA2_ASSETS, SIGLIP_SO400M_REPO, GEMMA2_TEXT_REPOS
+
+
+DOCS_REPOS = {
+    "technical_report": "google/paligemma2-technical-report",
+    "model_card": "google/paligemma2-3b-pt-224",
+}
+
+
+def verify_repo(repo_id: str) -> Dict[str, str]:
+    api = HfApi()
+    try:
+        info = api.model_info(repo_id)
+        return {"repo_id": repo_id, "exists": True, "last_modified": str(info.last_modified)}
+    except Exception as exc:  # pragma: no cover - network failure path
+        return {"repo_id": repo_id, "exists": False, "error": str(exc)}
+
+
+def main() -> None:
+    results = {
+        "paligemma2_weights": [verify_repo(asset.tag) for asset in PALIGEMMA2_ASSETS.values()],
+        "siglip": verify_repo(SIGLIP_SO400M_REPO),
+        "gemma_text": [verify_repo(repo) for repo in GEMMA2_TEXT_REPOS.values()],
+        "docs": [verify_repo(repo) for repo in DOCS_REPOS.values()],
+    }
+    print(json.dumps(results, indent=2))
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry
+    main()

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+import json
+import runpy
+from pathlib import Path
+
+import pytest
+pd = pytest.importorskip("pandas")
+pytest.importorskip("pyarrow")
+import torch
+from torch import nn
+from types import SimpleNamespace
+
+from metrics.training_dev_metrics import MetricConfig, TrainingDevMetrics
+from paligemma2.training.pipeline import CheckpointManager
+
+
+class TinyModel(nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.linear = nn.Linear(4, 4)
+
+    def forward(self, input_ids: torch.Tensor, **_) -> torch.Tensor:
+        logits = self.linear(input_ids.float())
+        loss = torch.nn.functional.mse_loss(logits, torch.zeros_like(logits))
+        return SimpleNamespace(loss=loss)
+
+
+def test_training_metrics_logging(tmp_path: Path) -> None:
+    model = TinyModel()
+    optimizer = torch.optim.SGD(model.parameters(), lr=0.1)
+    cfg = MetricConfig(log_dir=str(tmp_path), log_every=1, parquet_rollover_rows=5)
+    metrics = TrainingDevMetrics(cfg, model=model, optimizer=optimizer)
+
+    batch = torch.ones(2, 4)
+    for step in range(3):
+        metrics.on_step_end(loss=1.0 + step, batch_size=batch.size(0), lr=0.1)
+    metrics.finalize()
+
+    parquet = tmp_path / "METRICS" / "train_timeseries.parquet"
+    assert parquet.exists()
+    df = pd.read_parquet(parquet)
+    assert set(["loss", "grad_norm", "weight_norm"]).issubset(df.columns)
+
+
+def test_checkpoint_manifest(tmp_path: Path) -> None:
+    model = TinyModel()
+    optimizer = torch.optim.SGD(model.parameters(), lr=0.1)
+    cfg = MetricConfig(log_dir=str(tmp_path), log_every=1)
+    metrics = TrainingDevMetrics(cfg, model=model, optimizer=optimizer)
+    manager = CheckpointManager(save_dir=str(tmp_path / "ckpts"))
+
+    dummy_state = {"input_ids": torch.ones(2, 4)}
+    metrics.global_step = 10
+    manager.save(step=10, stage="stage1", model=model, optimizer=optimizer, scheduler=None, metrics=metrics)
+    manifest = tmp_path / "CHECKPOINT_MANIFEST.parquet"
+    assert manifest.exists()
+    df = pd.read_parquet(manifest)
+    assert df.shape[0] == 1
+    assert df.iloc[0]["stage"] == "stage1"
+
+
+def test_checkpoint_indexer_script(tmp_path: Path, monkeypatch) -> None:
+    manifest = tmp_path / "CHECKPOINT_MANIFEST.parquet"
+    pd.DataFrame([
+        {"ts": 0.0, "step": 1, "stage": "stage1", "ckpt_path": "a", "param_stats": {}},
+        {"ts": 0.0, "step": 2, "stage": "stage1", "ckpt_path": "b", "param_stats": {}},
+    ]).to_parquet(manifest)
+    out_path = tmp_path / "summary.json"
+    monkeypatch.setattr(
+        "sys.argv",
+        [
+            "checkpoint_indexer.py",
+            "--log-dir",
+            str(tmp_path),
+            "--out",
+            str(out_path),
+        ],
+    )
+    runpy.run_path("scripts/checkpoint_indexer.py")
+    assert out_path.exists()
+    payload = json.loads(out_path.read_text())
+    assert payload["num_checkpoints"] == 2


### PR DESCRIPTION
## Summary
- add PaliGemma 2 configuration, model wiring, and three-stage trainer with checkpointing support
- implement developmental interpretability metrics pipeline with curvature, LLC, and parameter geometry logging
- provide asset verification/downloader scripts, evaluation/post-hoc tooling, and documentation for data placeholders
- add unit tests covering metric logging and checkpoint manifest indexing

## Testing
- pytest